### PR TITLE
make sure we have a white background even when running under mod_perl

### DIFF
--- a/lib/GD/Barcode.pm
+++ b/lib/GD/Barcode.pm
@@ -69,6 +69,7 @@ sub plot($$$$$) {
         $gdNew = GD::Image->new( $iWidth, $iHeight );
         $cWhite = $gdNew->colorAllocate( 255, 255, 255 );
         $cBlack = $gdNew->colorAllocate( 0,   0,   0 );
+        $gdNew->filledRectangle( 0, 0, $iWidth, $iHeight, $cWhite );
 
         my $iPos = $iStart;
         foreach my $cWk ( split( //, $sBarcode ) ) {


### PR DESCRIPTION
I had the issue when using GD::Barcode with mod_perl that after a while the image background would be black occasionally. Explicitely drawing a white background fixed the issue.