### PR TITLE
Silence "uninitialized" Warning in QRcode

### DIFF
--- a/lib/GD/Barcode/QRcode.pm
+++ b/lib/GD/Barcode/QRcode.pm
@@ -122,7 +122,7 @@ sub init {
         while ($iFlg) {
             if ( $iRestBits > $iBuffBit ) {
                 $aCodeWords[$iCodeWords] =
-                  ( ( $aCodeWords[$iCodeWords] << $iBuffBit ) | $sBuff );
+                  ( ( ( $aCodeWords[$iCodeWords] // 0 ) << $iBuffBit ) | $sBuff );
                 $iRestBits -= $iBuffBit;
                 $iFlg = 0;
             }
@@ -214,8 +214,8 @@ sub init {
     for ( my $iMatrixRemain = $iRemainBits ; $iMatrixRemain ; $iMatrixRemain-- )
     {
         my $iRemainBitTmp = $iMatrixRemain + ( $iMaxCodeWords * 8 );
-        $aCont[ $aMatrixX[$iRemainBitTmp] ][ $aMatrixY[$iRemainBitTmp] ] =
-          ( 255 ^ $aMask[$iRemainBitTmp] );
+        $aCont[ $aMatrixX[$iRemainBitTmp] // 0 ][ $aMatrixY[$iRemainBitTmp] // 0 ] =
+          ( 255 ^ ( $aMask[$iRemainBitTmp] // 0 ) );
     }
 
     # ---- mask select


### PR DESCRIPTION
Rather than simply using `no warnings "uninitialized"`, I figured it'd be slightly more correct to at least add `// 0` in places where values hadn't been assigned yet...

PS — I haven't studied the algorithm enough to know if there's a better way/place to initialize those array elements, but this shouldn't actually break any logic; uninitialized array indices and arithmetic values will default to zero, anyway.