### PR TITLE
Always require GD for plot in Code39

### DIFF
--- a/lib/GD/Barcode/Code39.pm
+++ b/lib/GD/Barcode/Code39.pm
@@ -93,6 +93,7 @@ sub plot {
     my $sPtn   = $oThis->barcode();
 
     #Create Image
+    require GD;
     my $iHeight = ( $hParam{Height} ) ? $hParam{Height} : 50;
     my ( $oGd, $cBlack );
     if ( $hParam{NoText} ) {
@@ -100,7 +101,6 @@ sub plot {
           GD::Barcode::plot( $sPtn, length($sPtn), $iHeight, 0, 0 );
     }
     else {
-        require GD;
         my ( $fW, $fH ) = ( GD::Font->Small->width, GD::Font->Small->height );
         my $iWidth = length($sPtn);
 


### PR DESCRIPTION
this fixes plot failing when NoText is set.

```
use GD::Barcode::Code39;
GD::Barcode::Code39->new('*12345*')->plot( NoText => 1 )->png;
```
fails with:
```
Runtime error: Can't call method "png" on an undefined value at ...
```